### PR TITLE
Add a generator parameter to make function but default to identity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@
 export type Brand<
   Base,
   Branding,
-  ReservedName extends string = '__type__'
+  ReservedName extends string = '__type__',
 > = Base & {[K in ReservedName]: Branding} & {__witness__: Base};
 
 /**
@@ -36,7 +36,7 @@ export type Brand<
  * branding type. By itself it is not useful, but it can act as type constraint
  * when manipulating branded types in general.
  */
-export type AnyBrand = Brand<any, any>;
+export type AnyBrand = Brand<unknown, any>;
 
 /**
  * `BaseOf` is a type that takes any branded type `B` and yields its base type.
@@ -55,7 +55,10 @@ export type BaseOf<B extends AnyBrand> = B['__witness__'];
  * // A Brander<UserId> would take a number and return a UserId
  * ```
  */
-export type Brander<B extends AnyBrand> = (underlying: BaseOf<B>) => B;
+export type Brander<B extends AnyBrand> = {
+  (underlying?: BaseOf<B>): B;
+  (): B;
+};
 
 /**
  * A generic function that, when given some branded type, can take a value with
@@ -72,7 +75,7 @@ export type Brander<B extends AnyBrand> = (underlying: BaseOf<B>) => B;
  * const UserId: Brander<UserId> = identity;
  * ```
  */
-export function identity<B extends AnyBrand>(underlying: BaseOf<B>): B {
+export function identity<B extends AnyBrand>(underlying?: BaseOf<B>): B {
   return underlying as B;
 }
 
@@ -89,6 +92,6 @@ export function identity<B extends AnyBrand>(underlying: BaseOf<B>): B {
  * const myUserId = UserId(42);
  * ```
  */
-export function make<B extends AnyBrand>(): Brander<B> {
-  return identity;
+export function make<B extends AnyBrand>(generator: Brander<B> = identity) {
+  return generator;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import {AnyBrand, identity, make} from '../src/index';
+import {AnyBrand, BaseOf, identity, make} from '../src/index';
 
 describe('identity', () => {
   it('returns the same value', () => {
@@ -10,6 +10,16 @@ describe('identity', () => {
 
 describe('make', () => {
   it('returns `identity`', () => {
-    expect(make<AnyBrand>()).toBe(identity);
+    const brander = make<AnyBrand>();
+    expect(brander).toBe(identity);
+    expect(brander(42)).toBe(42);
+  });
+  it('returns `generator`', () => {
+    function generator<B extends AnyBrand>(): BaseOf<B> {
+      return 'generated';
+    }
+    const brander = make(generator);
+    expect(brander).toBe(generator);
+    expect(brander()).toBe('generated');
   });
 });


### PR DESCRIPTION
This allows to use something like `uuid`

```ts
import { v4 as uuidv4 } from "uuid";
import { Brand, make } from "ts-brand";

export type User = {
  id: Brand<string, User>;
  name: string;
};

export const UserId = make<User["id"]>(uuidv4);

export type Post = {
  id: Brand<string, Post>;
  authorId: User["id"];
  title: string;
  body: string;
};

export const PostId = make<Post["id"]>();

function getPost(): Post {
  return ({
    id: PostId("1234567890"),
    authorId: UserId(),
    title: "First Post",
    body: "Lorem Ipsum"
  });
}

/** 
{
  id: "1234567890"
  authorId: "343575cb-853c-4927-b5bd-8a6a27ee7c21"
  title: "First Post"
  body: "Lorem Ipsum"
}
**/
```